### PR TITLE
docs: elaborate in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,46 @@
 
 This repository contains test suites for building proposals for CompoundGovernor / OpenZeppelin GovernorBravo. The repository is designed with [foundry](https://book.getfoundry.sh).
 
+### Example NounsDAO 500 `wstETH` -> `rETH`
+
+Want to demonstrate setting up a vote and executing a swap of 500 `wstETH` to `rETH`
+
+1. Approve the required amount of `stETH` to wrap into `wstETH`.
+2. Wrap `stETH` into `wstETH`
+3. Approve the to-be-created `Safe` (in pt. 4) to use the DAO's `wstETH`
+4. Create the `ComposableCoW` compatible `Safe` contract with:
+    - `threshold` of 1
+    - `owner` set to the `NounsDAOExecutor` address (ie. all executions on the `Safe` are bound by timelock)
+5. Execute post-Safe creation configuration and create conditional order:
+a. Set `ComposableCoW` as the domain verifier for `GPv2Settlement`
+b. Set an allowance for `GPv2VaultRelayer` to use the `wstETH` from the `Safe` contract
+c. Do `transferFrom` of the wstETH to the `Safe` contract
+d. Create the TWAP order on `ComposableCoW` via the `Safe` contract
+    - `sellToken` set to the wstETH address
+    - `buyToken` set to the rETH address
+    - `sellAmount` set to 500 wstETH
+    - `buyAmount` TBD
+    - `receiver` set to the `NounsDAOExecutor` address (all funds on swap move to the timelock)
+6. Enforce that the allowance for `wstETH` to be spent from the timelock controller is set back to zero
+
+#### Risk Mitigation
+
+1. Any `Safe` that is created that holds `NounsDAO` funds, must be subject to the timelock controller nature of `NounsDAOExecutor`.
+2. The sole owner of the `Safe` shall be the `NounsDAOExecutor`.
+3. **NO** funds are sent to the to-be-created `Safe` in the atomic transaction bundle, and are instead *pulled* from the `NounsDAOExecutor`. This avoids the unlikely situation where a pre-calculated `Safe` address (prior to `SafeProxyFactory.createProxyWithNonce`) has been determined incorrectly and funds are sent to an unrecoverable address.
+4. Approvals for spending on `NounsDAOExecutor` from the to-be-created `Safe` are zeroed at the end of the transaction bundle (though, should already be zero). 
+
+#### Verification Process
+
+1. Prove that the process can be undertaken from the context of the `NounsDAOExecutor` (ie. the timelock).
+   This means we use `vm.prank` to impersonate the `NounsDAOExecutor` and execute the swap.
+2. Do a full-stack test that:
+   - Proposes the transaction bundle
+   - Vote on the proposal (to affirm).
+   - Queue the proposal (on successful vote).
+   - Execute the proposal (verify transaction bundle executes correctly).
+   - **To be completed:** Verify via settlement that the discrete orders settle correctly.
+
 ## Usage
 
 The test suite is designed to run in a **forked** environment. Running in a self-contained environment is out of scope due to the large number of dependencies that are required. To run the test suite:

--- a/test/Proposal.t.sol
+++ b/test/Proposal.t.sol
@@ -74,34 +74,6 @@ contract ProposalTest is Test {
         bool postInit;
     }
 
-    // Want to demonstrate setting up a vote and executing a swap of 500 wstETH to rETH
-    // 1. Approve the required amount of stETH to wrap into wstETH
-    // 2. Wrap stETH into wstETH
-    // 3. Approve the to-be-created `Safe` (in pt. 4) to use the DAO's wstETH
-    // 4. Create the `ComposableCoW` compatible `Safe` contract with:
-    //   - `threshold` of 1
-    //   - `owner` set to the `NounsDAOExecutor` address (ie. all executions on the `Safe` are bound by timelock)
-    // 5. Execute post-Safe creation configuration and create conditional order:
-    //    a. Set `ComposableCoW` as the domain verifier for `GPv2Settlement`
-    //    b. Set an allowance for `GPv2VaultRelayer` to use the wstETH from the `Safe` contract
-    //    c. Do `transferFrom` of the wstETH to the `Safe` contract
-    //    d. Create the TWAP order on `ComposableCoW` via the `Safe` contract
-    //       - `sellToken` set to the wstETH address
-    //       - `buyToken` set to the rETH address
-    //       - `sellAmount` set to 500 wstETH
-    //       - `buyAmount` TBD
-    //       - `receiver` set to the `NounsDAOExecutor` address (all funds on swap move to the timelock)
-    // 6. Enforce that the allowance for `wstETH` to be spent from the timelock controller is set back to zero
-    //
-    // Risks: If a discrete order fails, that part of the swap will be left in the `Safe` contract.
-    //        Funds are still retrievable, however as the `Safe` contract is owned by the `NounsDAOExecutor`
-    //        the funds will be locked for the duration of the timelock.
-    //
-    // Process:
-    // 1. Prove that the process can be undertaken from the context of the `NounsDAOExecutor` (ie. the timelock).
-    //    This means we use `vm.prank` to impersonate the `NounsDAOExecutor` and execute the swap.
-    // 2. Create the proposal calldata.
-
     // --- constants
 
     uint256 constant TOTAL_SELL = 500;


### PR DESCRIPTION
This PR:

1. Moves broader documentation from the test suite into the README.md so browsers of repositories can get a better understanding of the repository's context.