### PR TITLE
chore: use dust + include proposal text

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,9 +1,6 @@
 [submodule "lib/forge-std"]
 	path = lib/forge-std
 	url = https://github.com/foundry-rs/forge-std
-[submodule "lib/nounsdao"]
-	path = lib/nounsdao
-	url = https://github.com/nounsDAO/nouns-monorepo
 [submodule "lib/composable"]
 	path = lib/composable
 	url = https://github.com/cowprotocol/composable-cow
@@ -16,6 +13,3 @@
 [submodule "lib/byteslib"]
 	path = lib/byteslib
 	url = https://github.com/GNSPS/solidity-bytes-utils
-[submodule "lib/openzeppelin-contracts-upgradeable"]
-	path = lib/openzeppelin-contracts-upgradeable
-	url = https://github.com/OpenZeppelin/openzeppelin-contracts-upgradeable

--- a/.gitmodules
+++ b/.gitmodules
@@ -16,3 +16,6 @@
 [submodule "lib/byteslib"]
 	path = lib/byteslib
 	url = https://github.com/GNSPS/solidity-bytes-utils
+[submodule "lib/openzeppelin-contracts-upgradeable"]
+	path = lib/openzeppelin-contracts-upgradeable
+	url = https://github.com/OpenZeppelin/openzeppelin-contracts-upgradeable

--- a/foundry.toml
+++ b/foundry.toml
@@ -3,4 +3,7 @@ src = "src"
 out = "out"
 libs = ["lib"]
 
+# Read permissions for the proposal text
+fs_permissions = [{ access = "read", path = "./"}]
+
 # See more config options https://github.com/foundry-rs/foundry/tree/master/config

--- a/proposal.txt
+++ b/proposal.txt
@@ -1,0 +1,77 @@
+## Description
+
+Following the [recent proposal](https://nouns.wtf/vote/320) to test CronFi’s TWAMM solution for [LST diversification](https://etherscan.io/address/0x0BC3807Ec262cB779b38D65b38158acC3bfedE10) of Nouns treasury, we at CoW Protocol would like to propose testing execution using our unique batch auction process before proceeding with the full 7k ETH amount. 
+
+There’s been interest in diversifying [Nouns DAO treasury](https://etherscan.io/address/0x0BC3807Ec262cB779b38D65b38158acC3bfedE10), specifically stETH→rETH. Recently some twitter avatars have [posted](https://twitter.com/0x70626a/status/1684936056443969536) a good analysis of the 500 ETH TWAMM trade, specifically, that the trade resulted in 518.51 rETH received for 500 wstETH (a whopping 1.25% slippage for a stable swap!). We believe CoW Protocol will provide a much more competitive execution price, that is compatible with fair market prices.
+
+## Background
+
+CoW Protocol has been using a multi-token batch auction on Ethereum mainnet for over two years, facilitating [>$26.8B of trading volume](https://dune.com/cowprotocol/cowswap). CoW Protocol uniquely allows its users to get best execution prices even with a lax slippage tolerance thanks to 15 competitive solvers participating in an auction mechanism that protects the users by granting the right to execute the trade to the solver offering maximal price improvement.
+
+CoW Protocol is used by a [number of DAOs](https://cow.fi/daos) for their trading operations including ENS, Aave, Nexus Mutual, Gnosis, Karpatkey, Olympus DAO, Badger DAO, Yearn and more. 
+
+## Advantages
+
+CoW Protocol pioneered intent-based trading since its inception in early 2021. This allows users to define order parameters without specifying the actual execution path (`calldata`). Users should expect the most optimised execution route to be chosen by the winning solver at the time of execution. 
+
+## Considerations
+
+Given a sell order of 500 wstETH→rETH there are several options for order placement that can provide different properties. We'll focus on a *TWAP* order setup although it seems to not be necessary in a smaller 500 ETH trade - the purpose is to demonstrate how a larger order could be set up.
+
+For a 500 wstETH→rETH we propose to use a TWAP order of 5 equal parts worth 100 wstETH each. This may result in an execution up to 525 rETH.
+![](https://hackmd.io/_uploads/BJfUbBKo2.png)
+
+### `TWAP` Conditional order
+
+* Launch date: August 17th, 2023. [See twitter post.](https://twitter.com/CoWSwap/status/1692152855694803112?s=20)
+* Transactional volume: ~$1.7M. [See dune query](https://dune.com/cowprotocol/cow-swap-limit-orders-kpis).
+
+The TWAP [implementation](https://github.com/cowprotocol/composable-cow) uses a constant limit price across each. Given the stability of wstETH→rETH, the limit price may be set in advance with a high confidence that this will be representative at the time the proposal is executed (and for the duration of the TWAP).
+
+Order parameters suggested for this proposal:
+* Limit price: 1 wstETH = 1.038 rETH. This includes 1% slippage tolerance to allow for charging a fee from the sell token and to get higher confidence in execution. **It is still expected to be executed with a much lower slippage in practice.** See the above mentioned dune dashboard's *'order surplus'* whereby the order's slippage is protected.
+* 5 equal parts of 100 wstETH
+* Time intervals of two hours between parts 
+
+## Methodology
+
+To achieve this TWAP, the proposed transaction bundle will:
+
+1. Wrap the required `stETH` to `wstETH` so that it may be traded.
+2. Create a `Safe` owned by the DAO treasury that is used as a staging contract for the TWAP.
+3. Trigger the TWAP, with the resulting `rETH` from each swap being sent directly back to the DAO treasury.
+
+### Use of `Safe`
+
+* Developers: `Safe`
+* Audits: [See their Github Repository](https://github.com/safe-global/safe-contracts/tree/af488f0a649a3be2ea01e0f7a6af1587d0250c2d/docs).
+
+The `Safe` is used as a staging area for the funds used in the TWAP. As CoW Protocol uses intent based trading, the `owner` of the order needs to sign their intent (done using a private key for an `EOA`, done using [EIP-1271](https://eips.ethereum.org/EIPS/eip-1271) for a smart contract). 
+
+With this requirement in mind, the DAO treasury contract for Nouns doesn't support EIP-1271. This is why a `Safe` is used in combination with `ComposableCoW` (detailed below).
+
+The `Safe` that is created in the proposal bundle **ensures that the only owner is set to the DAO Treasury**. At all times, the funds remain under the direct control of the DAO treasury with the same timelock conditions.
+
+#### Execution Risk
+
+In the transaction bundle funds are sent atomically to a newly created `Safe`. This means that the `Safe`'s address needs to be calculated beforehand. This is done using `CREATE2` logic, therefore the `Safe` is created at a deterministic address. The flow:
+
+1. DAO Treasury sets an approval on `wstETH` for the to-be-created `Safe`.
+2. The `Safe` is created and initialised.
+3. The funds are **PULLED** from the DAO Treasury to the `Safe`.
+
+Critically, with the above methodology there is *no ability for funds to be sent to an address where they are not retrievable*.
+
+### Use of `ComposableCoW` / `TWAP`
+
+* Developer: mfw78 (funded by CowDAO Grants Program, and now a [Core Contributor to CoW Protocol](https://snapshot.org/#/cowgrants.eth/proposal/0x0202a88c6792d1bd1e534cf1da94769130f495e72247e666b4afff8b22da9db0)).
+* Audits (jointly funded by `Safe` and CoW Protocol): [Ackee](https://github.com/cowprotocol/composable-cow/blob/main/audits/ackee-blockchain-cow-protocol-composablecow-extensiblefallbackhandler-report-1.2.pdf), [Gnosis Internal](https://github.com/cowprotocol/composable-cow/blob/main/audits/gnosis-ComposableCoWMayJul2023.pdf).
+* Other: Repository recently on-boarded to [CoW Protocol GitHub organisation](https://github.com/cowprotocol/).
+
+`ComposableCoW` is a conditional smart order framework that was [incubated by the CoW Grants Program](https://snapshot.org/#/cowgrants.eth/proposal/0xb7815ca1f5aea2ec537295fd452332680eb1be379f3356950dc8ba151d83f9c5). `TWAP` is an order type implemented in the `ComposableCoW` framework. The contracts are thoroughly tested and audited. To date, volume processed exceeds $1.7M.
+
+Using `ComposableCoW`, a smart contract (such as the `Safe` deployed in the proposal) is able to autonomously indicate its intent to trade. This intent is monitored by a *Watch Tower* (currently a Tenderly Web3 Action, deployed by the CoW Protocol team), with the intent relayed to the CoW Protocol API. In this framework - for TWAP, unlike `Milkman` - the smart contract specifies the *entire order structure to be submitted to the API*. There are no trust assumptions placed in the Watch Tower (besides the Watch Tower not running, leading to a griefing attack, but CoW Protocol for reputational reasons are incentivised to keep the Watch Tower operational).
+
+#### Differences compared to `Milkman`
+
+Both were funded by the CoW Protocol Grants Program. `Milkman` seeks to solve the issue of an autonomous swap from ABC→XYZ tokens, whereas `ComposableCoW` provides an entire framework for producing *conditional* orders. TWAP is an example of a conditional order built with this framework - allowing a large trade to settle in multiple parts over time, minimising price impact.

--- a/remappings.txt
+++ b/remappings.txt
@@ -10,7 +10,6 @@ forge-std/=lib/forge-std/src/
 helpers/=lib/composable/lib/balancer/src/lib/helpers/
 math/=lib/composable/lib/balancer/src/lib/math/
 murky/=lib/composable/lib/murky/src/
-nounsdao/=lib/nounsdao/packages/nouns-contracts/contracts/
 openzeppelin-contracts/=lib/composable/lib/canonical-weth/lib/openzeppelin-contracts/
 openzeppelin/=lib/openzeppelin/
 safe/=lib/safe/contracts/

--- a/src/interfaces/NounsDAOContracts.sol
+++ b/src/interfaces/NounsDAOContracts.sol
@@ -1,0 +1,73 @@
+// SPDX-License-Identifier: UNLICENSED
+
+pragma solidity ^0.8.13;
+
+struct ProposalCondensed {
+    /// @notice Unique id for looking up a proposal
+    uint256 id;
+    /// @notice Creator of the proposal
+    address proposer;
+    /// @notice The number of votes needed to create a proposal at the time of proposal creation. *DIFFERS from GovernerBravo
+    uint256 proposalThreshold;
+    /// @notice The minimum number of votes in support of a proposal required in order for a quorum to be reached and for a vote to succeed at the time of proposal creation. *DIFFERS from GovernerBravo
+    uint256 quorumVotes;
+    /// @notice The timestamp that the proposal will be available for execution, set once the vote succeeds
+    uint256 eta;
+    /// @notice The block at which voting begins: holders must delegate their votes prior to this block
+    uint256 startBlock;
+    /// @notice The block at which voting ends: votes must be cast prior to this block
+    uint256 endBlock;
+    /// @notice Current number of votes in favor of this proposal
+    uint256 forVotes;
+    /// @notice Current number of votes in opposition to this proposal
+    uint256 againstVotes;
+    /// @notice Current number of votes for abstaining for this proposal
+    uint256 abstainVotes;
+    /// @notice Flag marking whether the proposal has been canceled
+    bool canceled;
+    /// @notice Flag marking whether the proposal has been vetoed
+    bool vetoed;
+    /// @notice Flag marking whether the proposal has been executed
+    bool executed;
+    /// @notice The total supply at the time of proposal creation
+    uint256 totalSupply;
+    /// @notice The block at which this proposal was created
+    uint256 creationBlock;
+}
+
+// DAO interfaces
+interface INounsDAOLogic {
+    function execute(uint256 proposalId) external;
+    function _setProposalThresholdBPS(uint256 newProposalThresholdBPS) external;
+    function _setMinQuorumVotesBPS(uint16 newMinQuorumVotesBPS) external;
+    function propose(
+        address[] memory targets,
+        uint256[] memory values,
+        string[] memory signatures,
+        bytes[] memory calldatas,
+        string memory description
+    ) external returns (uint256);
+    function proposal(
+        uint256 proposalId
+    ) external view returns (ProposalCondensed memory);
+    function proposeOnTimelockV1(
+        address[] memory targets,
+        uint256[] memory values,
+        string[] memory signatures,
+        bytes[] memory calldatas,
+        string memory description
+    ) external returns (uint256);
+    function castVote(uint256 proposalId, uint8 support) external;
+    function queue(uint256 proposalId) external;
+    function votingDelay() external view returns (uint256);
+    function votingPeriod() external view returns (uint256);
+}
+
+interface INounsTimelock {
+    function delay() external view returns (uint256);
+}
+
+interface INounsToken {
+    function mint() external returns (uint256);
+    function transferFrom(address from, address to, uint256 tokenId) external;
+}

--- a/src/interfaces/NounsDAOContracts.sol
+++ b/src/interfaces/NounsDAOContracts.sol
@@ -47,7 +47,7 @@ interface INounsDAOLogic {
         bytes[] memory calldatas,
         string memory description
     ) external returns (uint256);
-    function proposal(
+    function proposals(
         uint256 proposalId
     ) external view returns (ProposalCondensed memory);
     function proposeOnTimelockV1(

--- a/test/Proposal.t.sol
+++ b/test/Proposal.t.sol
@@ -133,7 +133,7 @@ contract ProposalTest is Test {
         }
         vm.stopPrank();
 
-        vm.roll(block.number + 1);
+        vm.roll(block.number + 2);
 
         // Now let's vote for the proposal, queue it, and execute it
         dao.castVote(359, 1);

--- a/test/Proposal.t.sol
+++ b/test/Proposal.t.sol
@@ -352,6 +352,10 @@ contract ProposalTest is Test {
 
         (bytes memory initializer, address STAGING_SAFE) = getSafe(RECEIVER, SALT_NONCE);
 
+        // Warp to time to execute proposal 356
+        vm.warp(1693054715);
+        oldDao.execute(356);
+
         // Do everything from the timelock
         vm.startPrank(address(timelock));
 

--- a/test/Proposal.t.sol
+++ b/test/Proposal.t.sol
@@ -34,8 +34,8 @@ import {GPv2Signing} from "composable/lib/cowprotocol/src/contracts/mixins/GPv2S
 import {GPv2AllowListAuthentication} from "composable/lib/cowprotocol/src/contracts/GPv2AllowListAuthentication.sol";
 
 // DAO contracts
-import {NounsDAOLogicV2} from "nounsdao/governance/NounsDAOLogicV2.sol";
-import {NounsDAOExecutor} from "nounsdao/governance/NounsDAOExecutor.sol";
+import {NounsDAOLogicV3} from "nounsdao/governance/NounsDAOLogicV3.sol";
+import {NounsDAOExecutorV2} from "nounsdao/governance/NounsDAOExecutorV2.sol";
 import {NounsToken} from "nounsdao/NounsToken.sol";
 
 // Misc Tokens
@@ -59,8 +59,11 @@ CurrentBlockTimestampFactory constant contextFactory =
 GPv2AllowListAuthentication constant allowList = GPv2AllowListAuthentication(0x2c4c28DDBdAc9C5E7055b4C863b72eA0149D8aFE);
 
 // DAO + DAO Token
-NounsDAOLogicV2 constant dao = NounsDAOLogicV2(payable(0x6f3E6272A167e8AcCb32072d08E0957F9c79223d));
-NounsDAOExecutor constant timelock = NounsDAOExecutor(payable(0x0BC3807Ec262cB779b38D65b38158acC3bfedE10));
+// The oldDao and dao are the same address, it's just the logic contract that has been upgraded
+NounsDAOLogicV2 constant oldDao = NounsDAOLogicV2(payable(0x6f3E6272A167e8AcCb32072d08E0957F9c79223d));
+NounsDAOLogicV3 constant dao = NounsDAOLogicV3(payable(0x6f3E6272A167e8AcCb32072d08E0957F9c79223d));
+// Post proposal 356, the timelock has moved to the new executor
+NounsDAOExecutorV2 constant timelock = NounsDAOExecutorV2(payable(0xb1a32FC9F9D8b2cf86C068Cae13108809547ef71));
 NounsToken constant nouns = NounsToken(0x9C8fF314C9Bc7F6e59A9d9225Fb22946427eDC03);
 address constant auctionHouse = 0x830BD73E4184ceF73443C15111a1DF14e495C706;
 
@@ -191,6 +194,10 @@ contract ProposalTest is Test {
             "approve(address,uint256)",
             abi.encodeWithSelector(IERC20.approve.selector, STAGING_SAFE, 0)
         );
+
+        // Warp to time to execute proposal 356
+        vm.warp(1693054715);
+        oldDao.execute(356);
 
         // Before we propose, set a fake low proposal threshold
         vm.startPrank(address(timelock));

--- a/test/Proposal.t.sol
+++ b/test/Proposal.t.sol
@@ -97,7 +97,7 @@ contract ProposalTest is Test {
     uint256 constant MAX_BPS = 10000;
 
     bytes32 constant CONDITIONAL_ORDER_SALT = keccak256("cows love nouns"); // todo
-    bytes32 constant TWAP_APPDATA = keccak256("need some cool appdata"); // todo
+    bytes32 constant TWAP_APPDATA = bytes32(0xc8879ab78d5d1c6ac89947aed258fc8228f30d633701a57ce7cdc5677f9930e7);
 
     TestAccount solver = TestAccountLib.createTestAccount("solver");
     TestAccount bob = TestAccountLib.createTestAccount("counterParty");

--- a/test/Proposal.t.sol
+++ b/test/Proposal.t.sol
@@ -57,8 +57,6 @@ CurrentBlockTimestampFactory constant contextFactory =
 GPv2AllowListAuthentication constant allowList = GPv2AllowListAuthentication(0x2c4c28DDBdAc9C5E7055b4C863b72eA0149D8aFE);
 
 // DAO + DAO Token
-// The oldDao and dao are the same address, it's just the logic contract that has been upgraded
-// INounsDAOLogic constant oldDao = INounsDAOLogic(payable(0x6f3E6272A167e8AcCb32072d08E0957F9c79223d));
 INounsDAOLogic constant dao = INounsDAOLogic(payable(0x6f3E6272A167e8AcCb32072d08E0957F9c79223d));
 // Post proposal 356, the timelock has moved to the new executor
 INounsTimelock constant timelock = INounsTimelock(payable(0xb1a32FC9F9D8b2cf86C068Cae13108809547ef71));
@@ -180,7 +178,7 @@ contract ProposalTest is Test {
         uint256[] memory values = new uint256[](6);
         string[] memory signatures = new string[](6);
         bytes[] memory calldatas = new bytes[](6);
-        string memory description = "Swap 500 wstETH for rETH";
+        string memory description = vm.readFile("proposal.txt");
 
         (bytes memory initializer, address STAGING_SAFE) = getSafe(RECEIVER, SALT_NONCE);
         uint256 stETHAmount = IWstETH(wstETH).getStETHByWstETH(tradeSize());

--- a/test/Proposal.t.sol
+++ b/test/Proposal.t.sol
@@ -110,7 +110,7 @@ contract ProposalTest is Test {
     function setUp() public {
         // Current state:
         // - Proposal 359 will move the last of the NounsDAO TreasuryV1 to the new treasury
-        ProposalCondensed memory propDetails = dao.proposal(359);
+        ProposalCondensed memory propDetails = dao.proposals(359);
 
         // For the tests, move to the block before we must have enough tokens for voting.
         vm.roll(propDetails.startBlock - 1);

--- a/test/Proposal.t.sol
+++ b/test/Proposal.t.sol
@@ -33,10 +33,39 @@ import {GPv2Interaction} from "composable/lib/cowprotocol/src/contracts/librarie
 import {GPv2Signing} from "composable/lib/cowprotocol/src/contracts/mixins/GPv2Signing.sol";
 import {GPv2AllowListAuthentication} from "composable/lib/cowprotocol/src/contracts/GPv2AllowListAuthentication.sol";
 
-// DAO contracts
-import {NounsDAOLogicV3} from "nounsdao/governance/NounsDAOLogicV3.sol";
-import {NounsDAOExecutorV2} from "nounsdao/governance/NounsDAOExecutorV2.sol";
-import {NounsToken} from "nounsdao/NounsToken.sol";
+// DAO interfaces
+interface INounsDAOLogic {
+    function execute(uint256 proposalId) external;
+    function _setProposalThresholdBPS(uint256 newProposalThresholdBPS) external;
+    function _setMinQuorumVotesBPS(uint16 newMinQuorumVotesBPS) external;
+    function propose(
+        address[] memory targets,
+        uint256[] memory values,
+        string[] memory signatures,
+        bytes[] memory calldatas,
+        string memory description
+    ) external returns (uint256);
+    function proposeOnTimelockV1(
+        address[] memory targets,
+        uint256[] memory values,
+        string[] memory signatures,
+        bytes[] memory calldatas,
+        string memory description
+    ) external returns (uint256);
+    function castVote(uint256 proposalId, uint8 support) external;
+    function queue(uint256 proposalId) external;
+    function votingDelay() external view returns (uint256);
+    function votingPeriod() external view returns (uint256);
+}
+
+interface INounsTimelock {
+    function delay() external view returns (uint256);
+}
+
+interface INounsToken {
+    function mint() external returns (uint256);
+    function transferFrom(address from, address to, uint256 tokenId) external;
+}
 
 // Misc Tokens
 import {IWstETH} from "../src/interfaces/IWstETH.sol";
@@ -60,11 +89,11 @@ GPv2AllowListAuthentication constant allowList = GPv2AllowListAuthentication(0x2
 
 // DAO + DAO Token
 // The oldDao and dao are the same address, it's just the logic contract that has been upgraded
-NounsDAOLogicV2 constant oldDao = NounsDAOLogicV2(payable(0x6f3E6272A167e8AcCb32072d08E0957F9c79223d));
-NounsDAOLogicV3 constant dao = NounsDAOLogicV3(payable(0x6f3E6272A167e8AcCb32072d08E0957F9c79223d));
+INounsDAOLogic constant oldDao = INounsDAOLogic(payable(0x6f3E6272A167e8AcCb32072d08E0957F9c79223d));
+INounsDAOLogic constant dao = INounsDAOLogic(payable(0x6f3E6272A167e8AcCb32072d08E0957F9c79223d));
 // Post proposal 356, the timelock has moved to the new executor
-NounsDAOExecutorV2 constant timelock = NounsDAOExecutorV2(payable(0xb1a32FC9F9D8b2cf86C068Cae13108809547ef71));
-NounsToken constant nouns = NounsToken(0x9C8fF314C9Bc7F6e59A9d9225Fb22946427eDC03);
+INounsTimelock constant timelock = INounsTimelock(payable(0xb1a32FC9F9D8b2cf86C068Cae13108809547ef71));
+INounsToken constant nouns = INounsToken(0x9C8fF314C9Bc7F6e59A9d9225Fb22946427eDC03);
 address constant auctionHouse = 0x830BD73E4184ceF73443C15111a1DF14e495C706;
 
 // Tokens


### PR DESCRIPTION
This PR: 

1. Adjusts the simulation such that it makes use of Proposal 359, which includes the movement of ~30 wstETH from Treasury V1 to Treasury V2.
2. Includes the proposal text in the description parameter, finalising the calldata.

Todo:

- [ ] Establish what `appData` to use.